### PR TITLE
Dynamic download of Sheep It client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:7
+FROM debian:8
 
 # File Author / Maintainer
 MAINTAINER AGSPhoenix
@@ -7,12 +7,14 @@ RUN  apt-get update -y \
   && apt-get install -y --no-install-recommends \
    openjdk-7-jre-headless \
    libxxf86vm1 \
+   wget \
 #Already pulled in by the JRE on Debian, but not on Ubuntu.
    libxi6
 
 RUN mkdir -p /sheep/cache
 
-ADD https://www.sheepit-renderfarm.com/media/applet/client-latest.php /sheep/sheepit.jar
+ADD startrenderer.sh /sheep/startrenderer.sh
+RUN chmod +x /sheep/startrenderer.sh
 
 WORKDIR /sheep
 
@@ -20,4 +22,4 @@ ENV user_name ""
 ENV user_password ""
 ENV cpu "1"
 
-CMD java -jar /sheep/sheepit.jar -ui text -login $user_name -password $user_password -cores $cpu -cache-dir /sheep/cache
+CMD ./startrenderer.sh

--- a/startrenderer.sh
+++ b/startrenderer.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+wget https://www.sheepit-renderfarm.com/media/applet/client-latest.php -O /sheep/sheepit.jar
+java -jar /sheep/sheepit.jar -ui text -login $user_name -password $user_password -cores $cpu -cache-dir /sheep/cache


### PR DESCRIPTION
The file obtained by ADD is only updated whenever there is a change on the repository.  I moved that to a script that downloads the client each time the container is started.  This way in order to download a  new client you simple shutdown and restart the container rather than depending on a new build.

Major Changes
- Moved to Debian 8.  There's a bug with the wget included with Debian 7 that doesn't correctly identify sheepit's SSL certificate which is issued by Let's Encrypt.
- Added wget. Needed for the script to download the client. Though I suppose curl could be used...

Went ahead and tested it here:

https://hub.docker.com/r/forneuszagan/sheepit-docker-test/
