### PR TITLE
Fix version grep

### DIFF
--- a/startrenderer.sh
+++ b/startrenderer.sh
@@ -2,7 +2,7 @@
 
 #Check for updates
 echo Checking for client updates...
-latestVersion=`curl --silent --head https://www.sheepit-renderfarm.com/media/applet/client-latest.php|grep -Po 'Content-Disposition:.*filename="?\Ksheepit-client-[\d\.]+'`
+latestVersion=`curl --silent --head https://www.sheepit-renderfarm.com/media/applet/client-latest.php|grep -Po 'content-disposition:.*filename="?\Ksheepit-client-[\d\.]+'`
 
 if [ ! -e $latestVersion.jar ]; then
     echo Updating client...


### PR DESCRIPTION
The recent server upgrade caused the header to be lowercased, leading to an empty $latestVersion and writes it into a file just named '.jar'
This fixes that circumstance.