### PR TITLE
Improve latestversion variable handling

### DIFF
--- a/startrenderer.sh
+++ b/startrenderer.sh
@@ -2,9 +2,14 @@
 
 #Check for updates
 echo Checking for client updates...
-latestVersion=`curl --silent --head https://www.sheepit-renderfarm.com/media/applet/client-latest.php|grep -Po 'content-disposition:.*filename="?\Ksheepit-client-[\d\.]+'`
+latestVersion=`curl --silent --head https://www.sheepit-renderfarm.com/media/applet/client-latest.php | \
+    grep -Po '(?i)content-disposition:.*filename="?(?-i)\Ksheepit-client-[\d\.]+\d'`
 
-if [ ! -e $latestVersion.jar ]; then
+if [ -z $latestVersion ]; then
+    #Empty latestVersion hints at a critical error
+    echo Failed parsing version information! Aborting.
+    exit 1
+elif [ ! -e $latestVersion.jar ]; then
     echo Updating client...
     rm -f sheepit-client*.jar
     #Download new client.

--- a/startrenderer.sh
+++ b/startrenderer.sh
@@ -6,8 +6,8 @@ latestVersion=`curl --silent --head https://www.sheepit-renderfarm.com/media/app
     grep -Po '(?i)content-disposition:.*filename="?(?-i)\Ksheepit-client-[\d\.]+\d'`
 
 if [ -z $latestVersion ]; then
-    #Empty latestVersion hints at a critical error
-    echo Failed parsing version information! Aborting.
+    #Empty latestVersion probably means a server or network issue that would prevent rendering
+    echo Unable to get latest version info; this is likely a network or server issue. Try checking the site and pulling updates, then submit a GitHub issue if that doesn't fix it.
     exit 1
 elif [ ! -e $latestVersion.jar ]; then
     echo Updating client...


### PR DESCRIPTION
Turning off case sensitivity for the part of "content-disposition filename" matching but not for the portion relating to 'sheepit-client'
I also noticed that it matches a '.' at the end,
this paired with the fact that the script uses '$latestVersion.jar' leads to a result with current var to be 'sheepit-client-6.20364.0..jar'
including that '/d' at the end of the expression addresses that.

Additionally, should the latestVersion variable be empty, we should abort and not write into a file just being named '.jar' and run that.
It does run the client but it is sorta broken and errors out that I would just attribute to undefined behaviour, let's not dip into that territory.