### PR TITLE
Add mechanism to drop root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,15 @@ RUN \
 		/tmp/*
 
 ADD startrenderer.sh /sheep/startrenderer.sh
-RUN chmod +x /sheep/startrenderer.sh
+ADD startrenderer.sh /sheep/initrenderer.sh
+RUN chmod +x /sheep/initrenderer.sh
 
 WORKDIR /sheep
 
-ENV user_name ""
-ENV user_password ""
-ENV cpu "0"
+ENV	user_name=""
+	user_password=""
+	cpu="0"
+	user_UID="1000"
+	user_GID="1000"
 
-CMD ./startrenderer.sh
+CMD ./initrenderer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,10 @@ RUN chmod +x /sheep/initrenderer.sh
 
 WORKDIR /sheep
 
-ENV	user_name=""
-	user_password=""
-	cpu="0"
-	user_UID="1000"
-	user_GID="1000"
+ENV user_name ""
+ENV user_password ""
+ENV cpu "0"
+ENV user_UID "1000"
+ENV user_GID "1000"
 
 CMD ./initrenderer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,43 @@
 FROM debian:buster-slim
 
 # File Author / Maintainer
-MAINTAINER AGSPhoenix
+LABEL maintainer=AGSPhoenix
+
+ARG DEBIAN_FRONTEND=noninteractive
+# Makes the apt-get process aware
+# of the docker build process env
+# so it doesn't complain as much
 
 RUN \
 # MAN folder needed for jre install
-     mkdir -p /usr/share/man/man1 \
-  && mkdir -p /sheep/cache \
-# Install JRE and curl
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
+	mkdir -p \
+		/usr/share/man/man1 \
+		/sheep/cache \
+	# Install JRE, curl and blender deps
+	&& apt-get update \
+	&& apt-get upgrade -y \
+	&& apt-get install -y --no-install-recommends \
 	default-jre-headless \
 	curl \
-	#Blender dependencies
-	libsdl1.2debian \
-	libxxf86vm1 \
-	libgl1-mesa-glx \
 	libglu1-mesa \
-	libxi6 \
- 	libxrender1 \
-	libxfixes3
+	# Blender dependencies of other sheepit containers explained:
+	# needed in the past:
+	#	libsdl1.2debian
+	#	libgl1-mesa-glx
+	# libglu1-mesa deps:
+	#	libxxf86vm1
+	#	libxfixes3
+	#	Dependency chain for both being
+	#	libglu1-mesa -> libgl1 -> libglx0 -> libglx-mesa0
+	# default-jre-headless (openjdk-11-jre-headless) deps:
+	#	libfreetype6
+	#	libxi6
+	#	libxrender1
+	&& apt-get -y autoremove \
+	&& apt-get -y clean \
+	&& rm -rf \
+		/var/lib/apt/lists/* \
+		/tmp/*
 
 ADD startrenderer.sh /sheep/startrenderer.sh
 RUN chmod +x /sheep/startrenderer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
 	mkdir -p \
 		/usr/share/man/man1 \
 		/sheep/cache \
-	# Install JRE, curl and blender deps
+	# Upgrade packages, install JRE, curl and blender deps
 	&& apt-get update \
 	&& apt-get upgrade -y \
 	&& apt-get install -y --no-install-recommends \

--- a/initrenderer.sh
+++ b/initrenderer.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+groupadd --gid $user_GID sheepit
+useradd --no-create-home \
+        --home-dir /sheep \
+        --uid $user_UID \
+        --gid $user_GID \
+        --inactive 0 \
+        sheepit
+# Adding a sheepit group and user
+
+chown sheepit:sheepit /sheep/startrenderer.sh
+chmod ug+x /sheep/startrenderer.sh
+chown -R sheepit:sheepit /sheep/
+# Setting file and dir permissions and ownerships
+# Makes sure the renderer can even operate
+
+su --command "/sheep/startrenderer.sh" \
+        --preserve-environment \
+        sheepit
+# Running sheepit as the configured user with the env preserved because the startrenderer script depends on it


### PR DESCRIPTION
Includes a new initrenderer.sh script to setup the renderer which in turn triggers startrenderer.sh
Adds two new env vars, namely user_UID and user_GID for the UID and GID to be used inside the container respectivly