### PR TITLE
Update package install instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN \
 	default-jre-headless \
 	curl \
 	libglu1-mesa \
+	libxi6 \
+	libxrender1 \
 	# Blender dependencies of other sheepit containers explained:
 	# needed in the past:
 	#	libsdl1.2debian
@@ -31,8 +33,6 @@ RUN \
 	#	libglu1-mesa -> libgl1 -> libglx0 -> libglx-mesa0
 	# default-jre-headless (openjdk-11-jre-headless) deps:
 	#	libfreetype6
-	#	libxi6
-	#	libxrender1
 	&& apt-get -y autoremove \
 	&& apt-get -y clean \
 	&& rm -rf \


### PR DESCRIPTION
Dependencies changed upstream
libxi6 and libxrender1 need to be explicitly installed now.