### PR TITLE
Added image size + language markup color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # A simple dockerized SheepIt render farm client
 
-After being appalled by @dapor2000's monstrous [1.2 GB SheepIt client](https://hub.docker.com/r/dapor/docker_sheepit_renderfarm/) image, I took it upon myself to build a somewhat more lightweight client, and after a few hours, came up with this Debian-based image that is a fifth the size, acts as a drop-in replacement, and auto-updates the client on container startup.
+After being appalled by @dapor2000's monstrous [1.2 GB SheepIt client](https://hub.docker.com/r/dapor/docker_sheepit_renderfarm/) image, I took it upon myself to build a somewhat more lightweight client, and after a few hours, came up with this Debian-based image that is a fifth the size(~ 384MB), acts as a drop-in replacement, and auto-updates the client on container startup.
 
 There's probably a little more room for fat trimming, since this was adapted from an old Ubuntu VM setup script, but I'm satisfied with where things are currently.
 
 ## Instructions
 Pretty similar to @dapor2000's, just swap out your username and password.
 
-```
+```bash
 docker run -d \
  --name "sheepit" \
  -e user_name=XXXXXX \


### PR DESCRIPTION
Note that in order to reduce even more the size of this image you could use : https://github.com/docker-slim/docker-slim
This tool is really powerful, and easy to install ! With the basic usage I was able to divide this image size by 2.